### PR TITLE
Fix manual input state sync for InputDecimal and InputNumber

### DIFF
--- a/packages/web-app/app/components/input-decimal.gts
+++ b/packages/web-app/app/components/input-decimal.gts
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 import cancelAll from 'ember-concurrency/helpers/cancel-all';
 import { fn } from '@ember/helper';
+import { action } from '@ember/object';
 
 interface InputDecimalSignature {
   Args: {
@@ -20,6 +21,16 @@ const displayValue = (value: number) => {
 
 export default class InputDecimal extends Component<InputDecimalSignature> {
   @tracked currentValue: number = parseFloat(this.args.value.toString());
+
+  @action
+  handleInput(event: Event) {
+    const target = event.target as HTMLInputElement;
+    const parsed = parseFloat(target.value);
+    if (!isNaN(parsed)) {
+      this.currentValue = parsed;
+      this.args.onChange?.(this.currentValue, this.args.name);
+    }
+  }
 
   // This task lets us hold down the +/- buttons to continue to increment/decrement the value.
   // It will decrease the delay the longer it's held down, causing the rate of change to speed up.
@@ -53,6 +64,7 @@ export default class InputDecimal extends Component<InputDecimalSignature> {
         name={{@name}}
         id={{@name}}
         value={{displayValue this.currentValue}}
+        {{on "input" this.handleInput}}
         step="0.1"
         class="w-full bg-primary text-primary-content font-bold text-center rounded-full"
         inputmode="decimal"

--- a/packages/web-app/app/components/input-decimal.gts
+++ b/packages/web-app/app/components/input-decimal.gts
@@ -4,7 +4,6 @@ import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 import cancelAll from 'ember-concurrency/helpers/cancel-all';
 import { fn } from '@ember/helper';
-import { action } from '@ember/object';
 
 interface InputDecimalSignature {
   Args: {
@@ -22,15 +21,14 @@ const displayValue = (value: number) => {
 export default class InputDecimal extends Component<InputDecimalSignature> {
   @tracked currentValue: number = parseFloat(this.args.value.toString());
 
-  @action
-  handleInput(event: Event) {
+  handleInput = (event: Event) => {
     const target = event.target as HTMLInputElement;
     const parsed = parseFloat(target.value);
     if (!isNaN(parsed)) {
       this.currentValue = parsed;
       this.args.onChange?.(this.currentValue, this.args.name);
     }
-  }
+  };
 
   // This task lets us hold down the +/- buttons to continue to increment/decrement the value.
   // It will decrease the delay the longer it's held down, causing the rate of change to speed up.

--- a/packages/web-app/app/components/input-number.gts
+++ b/packages/web-app/app/components/input-number.gts
@@ -4,7 +4,6 @@ import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 import cancelAll from 'ember-concurrency/helpers/cancel-all';
 import { fn } from '@ember/helper';
-import { action } from '@ember/object';
 
 interface InputNumberSignature {
   Args: {
@@ -18,15 +17,14 @@ interface InputNumberSignature {
 export default class InputNumber extends Component<InputNumberSignature> {
   @tracked currentValue: number = parseInt(this.args.value.toString());
 
-  @action
-  handleInput(event: Event) {
+  handleInput = (event: Event) => {
     const target = event.target as HTMLInputElement;
     const parsed = parseInt(target.value);
     if (!isNaN(parsed)) {
       this.currentValue = parsed;
       this.args.onChange?.(this.currentValue, this.args.name);
     }
-  }
+  };
 
   // This task lets us hold down the +/- buttons to continue to increment/decrement the value.
   // It will decrease the delay the longer it's held down, causing the rate of change to speed up.

--- a/packages/web-app/app/components/input-number.gts
+++ b/packages/web-app/app/components/input-number.gts
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 import cancelAll from 'ember-concurrency/helpers/cancel-all';
 import { fn } from '@ember/helper';
+import { action } from '@ember/object';
 
 interface InputNumberSignature {
   Args: {
@@ -16,6 +17,16 @@ interface InputNumberSignature {
 
 export default class InputNumber extends Component<InputNumberSignature> {
   @tracked currentValue: number = parseInt(this.args.value.toString());
+
+  @action
+  handleInput(event: Event) {
+    const target = event.target as HTMLInputElement;
+    const parsed = parseInt(target.value);
+    if (!isNaN(parsed)) {
+      this.currentValue = parsed;
+      this.args.onChange?.(this.currentValue, this.args.name);
+    }
+  }
 
   // This task lets us hold down the +/- buttons to continue to increment/decrement the value.
   // It will decrease the delay the longer it's held down, causing the rate of change to speed up.
@@ -49,6 +60,7 @@ export default class InputNumber extends Component<InputNumberSignature> {
         name={{@name}}
         id={{@name}}
         value={{this.currentValue}}
+        {{on "input" this.handleInput}}
         class="w-full bg-primary text-primary-content font-bold text-center rounded-full"
         inputmode="numeric"
         {{! NOTE: we might want to disable this and require the buttons to change the value }}

--- a/packages/web-app/tests/components/input-decimal-test.gts
+++ b/packages/web-app/tests/components/input-decimal-test.gts
@@ -1,0 +1,105 @@
+import { describe, expect, vi } from 'vitest';
+import { renderingTest } from 'ember-vitest';
+import { find, render } from '@ember/test-helpers';
+import { screen } from '@testing-library/dom';
+import { fireEvent } from 'testing-library-ember';
+import InputDecimal from '#components/input-decimal.gts';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const mouseClick = async (elem: Element, pressLength = 5) => {
+  fireEvent.pointerDown(elem);
+  await delay(pressLength);
+  fireEvent.pointerUp(elem);
+};
+
+const setup = async (initialValue = 10) => {
+  const value = initialValue;
+  await render(
+    <template>
+      <label for="yada">My Yada</label>
+      <InputDecimal @name="yada" @value={{value}} />
+    </template>
+  );
+
+  const input: HTMLInputElement = await screen.findByLabelText('My Yada');
+  const plus = await screen.findByText('+');
+  const minus = await screen.findByText('-');
+
+  return { input, plus, minus };
+};
+
+describe('Component | InputDecimal', () => {
+  renderingTest('it renders all the parts', async () => {
+    const { input } = await setup();
+    expect(input.value).toBe('10.0');
+  });
+
+  renderingTest('plus and minus work', async () => {
+    const { input, plus, minus } = await setup();
+
+    expect(input.value).toBe('10.0');
+    await mouseClick(plus);
+    expect(input.value).toBe('10.1');
+    await mouseClick(plus);
+    await mouseClick(plus);
+    expect(input.value).toBe('10.3');
+    await mouseClick(minus);
+    await mouseClick(minus);
+    await mouseClick(minus);
+    await mouseClick(minus);
+    expect(input.value).toBe('9.9');
+  });
+
+  renderingTest('manual input works', async () => {
+    const { input, plus } = await setup();
+
+    fireEvent.input(input, { target: { value: '15.5' } });
+    expect(input.value).toBe('15.5');
+
+    await mouseClick(plus);
+    expect(input.value).toBe('15.6');
+  });
+
+  renderingTest('it calls onChange on button click', async () => {
+    const value = 100;
+    const handleChange = vi.fn();
+
+    await render(
+      <template>
+        <InputDecimal
+          @name="changeme"
+          @value={{value}}
+          @onChange={{handleChange}}
+        />
+      </template>
+    );
+    const input = find('input');
+    expect(input!.value).toBe('100.0');
+
+    const plus = await screen.findByText('+');
+    await mouseClick(plus);
+
+    expect(handleChange).toHaveBeenCalledWith(100.1, 'changeme');
+  });
+
+  renderingTest('it calls onChange on manual input', async () => {
+    const value = 100;
+    const handleChange = vi.fn();
+
+    await render(
+      <template>
+        <InputDecimal
+          @name="changeme"
+          @value={{value}}
+          @onChange={{handleChange}}
+        />
+      </template>
+    );
+
+    const input: HTMLInputElement = await screen.findByRole('textbox');
+    fireEvent.input(input, { target: { value: '105.5' } });
+
+    expect(handleChange).toHaveBeenCalledWith(105.5, 'changeme');
+  });
+});

--- a/packages/web-app/tests/components/input-number-test.gts
+++ b/packages/web-app/tests/components/input-number-test.gts
@@ -135,4 +135,34 @@ describe('Component | InputNumber', () => {
 
     expect(handleChange).toHaveBeenCalledWith(101, 'changeme');
   });
+
+  renderingTest('manual input works', async () => {
+    const { input, plus } = await setup();
+
+    fireEvent.input(input, { target: { value: '15' } });
+    expect(input.value).toBe('15');
+
+    await mouseClick(plus);
+    expect(input.value).toBe('16');
+  });
+
+  renderingTest('it calls onChange on manual input', async () => {
+    const value = 100;
+    const handleChange = vi.fn();
+
+    await render(
+      <template>
+        <InputNumber
+          @name="changeme"
+          @value={{value}}
+          @onChange={{handleChange}}
+        />
+      </template>
+    );
+
+    const input: HTMLInputElement = await screen.findByRole('textbox');
+    fireEvent.input(input, { target: { value: '105' } });
+
+    expect(handleChange).toHaveBeenCalledWith(105, 'changeme');
+  });
 });


### PR DESCRIPTION
Fix manual input synchronization for InputDecimal and InputNumber components.

This commit resolves an issue where manual input values typed into the InputDecimal
and InputNumber components were not synchronized with the component's internal tracked
`currentValue` state. This would result in the manual input being overwritten when
the user clicked the increment/decrement buttons. It adds `on "input"` listeners
to appropriately parse and update the component state. Thorough Vitest unit tests have
also been written and verified to pass.

---
*PR created automatically by Jules for task [17178900665912337261](https://jules.google.com/task/17178900665912337261) started by @tcjr*