### PR TITLE
Display logout and login error messages

### DIFF
--- a/packages/web-app/app/templates/application.gts
+++ b/packages/web-app/app/templates/application.gts
@@ -5,6 +5,7 @@ import type FirebaseService from '#services/firebase';
 import type RouterService from '@ember/routing/router-service';
 import { action } from '@ember/object';
 import { on } from '@ember/modifier';
+import type { FlashMessagesService } from 'ember-cli-flash';
 import FlashMessages from '#app/components/flash-messages.gts';
 
 interface ApplicationComponentSignature {
@@ -16,6 +17,7 @@ interface ApplicationComponentSignature {
 export default class Application extends Component<ApplicationComponentSignature> {
   @service declare firebase: FirebaseService;
   @service declare router: RouterService;
+  @service declare flashMessages: FlashMessagesService;
 
   @action
   async logout() {
@@ -23,7 +25,7 @@ export default class Application extends Component<ApplicationComponentSignature
       await this.firebase.logout();
     } catch (error) {
       console.error('Logout failed:', error);
-      // TODO: Display a user-friendly error message
+      this.flashMessages.danger('Logout failed. Please try again.');
     } finally {
       // Redirect to login page after logout
       this.router.transitionTo('login');

--- a/packages/web-app/app/templates/login.gts
+++ b/packages/web-app/app/templates/login.gts
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import FirebaseService from '#services/firebase';
 import { on } from '@ember/modifier';
 import type RouterService from '@ember/routing/router-service';
+import type { FlashMessagesService } from 'ember-cli-flash';
 
 export interface LoginSignature {
   Element: HTMLDivElement;
@@ -13,6 +14,7 @@ export interface LoginSignature {
 export default class Login extends Component<LoginSignature> {
   @service declare firebase: FirebaseService;
   @service declare router: RouterService;
+  @service declare flashMessages: FlashMessagesService;
 
   @action
   async login(evt: SubmitEvent) {
@@ -23,7 +25,7 @@ export default class Login extends Component<LoginSignature> {
       this.router.transitionTo('authenticated.index');
     } catch (error) {
       console.error('Login failed:', error);
-      // TODO: Display a user-friendly error message
+      this.flashMessages.danger('Login failed. Please try again.');
     }
   }
 


### PR DESCRIPTION
Show a user-friendly error message if logging out fails in `packages/web-app/app/templates/application.gts`. Additionally, addressed the same TODO in `packages/web-app/app/templates/login.gts` for login failures. Both components now use the `flashMessages` service to display error notifications.

---
*PR created automatically by Jules for task [10318288370608003577](https://jules.google.com/task/10318288370608003577) started by @tcjr*