### PR TITLE
🧪 add unit tests for bp.ts utility

### DIFF
--- a/packages/web-app/tests/utils/bp-test.ts
+++ b/packages/web-app/tests/utils/bp-test.ts
@@ -4,25 +4,47 @@ import { getBpQuality } from '#app/utils/bp.ts';
 describe('Unit | Utility | bp', () => {
   describe('getBpQuality', () => {
     test('identifies hypertension-crisis', () => {
-      expect(getBpQuality({ systolic: 181, diastolic: 80 })).toBe('hypertension-crisis');
-      expect(getBpQuality({ systolic: 120, diastolic: 121 })).toBe('hypertension-crisis');
-      expect(getBpQuality({ systolic: 181, diastolic: 121 })).toBe('hypertension-crisis');
+      expect(getBpQuality({ systolic: 181, diastolic: 80 })).toBe(
+        'hypertension-crisis'
+      );
+      expect(getBpQuality({ systolic: 120, diastolic: 121 })).toBe(
+        'hypertension-crisis'
+      );
+      expect(getBpQuality({ systolic: 181, diastolic: 121 })).toBe(
+        'hypertension-crisis'
+      );
     });
 
     test('identifies hypertension-2', () => {
-      expect(getBpQuality({ systolic: 140, diastolic: 80 })).toBe('hypertension-2');
-      expect(getBpQuality({ systolic: 120, diastolic: 90 })).toBe('hypertension-2');
-      expect(getBpQuality({ systolic: 140, diastolic: 90 })).toBe('hypertension-2');
+      expect(getBpQuality({ systolic: 140, diastolic: 80 })).toBe(
+        'hypertension-2'
+      );
+      expect(getBpQuality({ systolic: 120, diastolic: 90 })).toBe(
+        'hypertension-2'
+      );
+      expect(getBpQuality({ systolic: 140, diastolic: 90 })).toBe(
+        'hypertension-2'
+      );
       // Just below crisis
-      expect(getBpQuality({ systolic: 180, diastolic: 120 })).toBe('hypertension-2');
+      expect(getBpQuality({ systolic: 180, diastolic: 120 })).toBe(
+        'hypertension-2'
+      );
     });
 
     test('identifies hypertension-1', () => {
-      expect(getBpQuality({ systolic: 130, diastolic: 70 })).toBe('hypertension-1');
-      expect(getBpQuality({ systolic: 110, diastolic: 80 })).toBe('hypertension-1');
-      expect(getBpQuality({ systolic: 130, diastolic: 80 })).toBe('hypertension-1');
+      expect(getBpQuality({ systolic: 130, diastolic: 70 })).toBe(
+        'hypertension-1'
+      );
+      expect(getBpQuality({ systolic: 110, diastolic: 80 })).toBe(
+        'hypertension-1'
+      );
+      expect(getBpQuality({ systolic: 130, diastolic: 80 })).toBe(
+        'hypertension-1'
+      );
       // Just below hypertension-2
-      expect(getBpQuality({ systolic: 139, diastolic: 89 })).toBe('hypertension-1');
+      expect(getBpQuality({ systolic: 139, diastolic: 89 })).toBe(
+        'hypertension-1'
+      );
     });
 
     test('identifies elevated', () => {

--- a/packages/web-app/tests/utils/bp-test.ts
+++ b/packages/web-app/tests/utils/bp-test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'vitest';
+import { getBpQuality } from '#app/utils/bp.ts';
+
+describe('Unit | Utility | bp', () => {
+  describe('getBpQuality', () => {
+    test('identifies hypertension-crisis', () => {
+      expect(getBpQuality({ systolic: 181, diastolic: 80 })).toBe('hypertension-crisis');
+      expect(getBpQuality({ systolic: 120, diastolic: 121 })).toBe('hypertension-crisis');
+      expect(getBpQuality({ systolic: 181, diastolic: 121 })).toBe('hypertension-crisis');
+    });
+
+    test('identifies hypertension-2', () => {
+      expect(getBpQuality({ systolic: 140, diastolic: 80 })).toBe('hypertension-2');
+      expect(getBpQuality({ systolic: 120, diastolic: 90 })).toBe('hypertension-2');
+      expect(getBpQuality({ systolic: 140, diastolic: 90 })).toBe('hypertension-2');
+      // Just below crisis
+      expect(getBpQuality({ systolic: 180, diastolic: 120 })).toBe('hypertension-2');
+    });
+
+    test('identifies hypertension-1', () => {
+      expect(getBpQuality({ systolic: 130, diastolic: 70 })).toBe('hypertension-1');
+      expect(getBpQuality({ systolic: 110, diastolic: 80 })).toBe('hypertension-1');
+      expect(getBpQuality({ systolic: 130, diastolic: 80 })).toBe('hypertension-1');
+      // Just below hypertension-2
+      expect(getBpQuality({ systolic: 139, diastolic: 89 })).toBe('hypertension-1');
+    });
+
+    test('identifies elevated', () => {
+      expect(getBpQuality({ systolic: 120, diastolic: 79 })).toBe('elevated');
+      expect(getBpQuality({ systolic: 129, diastolic: 70 })).toBe('elevated');
+    });
+
+    test('identifies low', () => {
+      expect(getBpQuality({ systolic: 89, diastolic: 70 })).toBe('low');
+      expect(getBpQuality({ systolic: 100, diastolic: 59 })).toBe('low');
+      expect(getBpQuality({ systolic: 89, diastolic: 59 })).toBe('low');
+    });
+
+    test('identifies normal', () => {
+      expect(getBpQuality({ systolic: 110, diastolic: 70 })).toBe('normal');
+      expect(getBpQuality({ systolic: 90, diastolic: 60 })).toBe('normal');
+      expect(getBpQuality({ systolic: 119, diastolic: 79 })).toBe('normal');
+    });
+
+    test('precedence: high BP conditions take precedence over low BP conditions', () => {
+      // Systolic is elevated (>= 120), diastolic is low (< 60)
+      // According to implementation:
+      // if (systolic >= 120 && diastolic < 80) return 'elevated';
+      // So it should be 'elevated'
+      expect(getBpQuality({ systolic: 125, diastolic: 50 })).toBe('elevated');
+    });
+  });
+});


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
The `getBpQuality` utility in `packages/web-app/app/utils/bp.ts` was previously untested. This PR adds a comprehensive suite of unit tests to ensure correct classification of blood pressure measurements.

### 📊 Coverage: What scenarios are now tested
- **hypertension-crisis**: Verified with systolic > 180 OR diastolic > 120.
- **hypertension-2**: Verified with systolic >= 140 OR diastolic >= 90.
- **hypertension-1**: Verified with systolic >= 130 OR diastolic >= 80.
- **elevated**: Verified with systolic >= 120 AND diastolic < 80.
- **low**: Verified with systolic < 90 OR diastolic < 60.
- **normal**: Verified with values within the normal range and boundary conditions.
- **Precedence**: Verified that high blood pressure conditions take precedence over low blood pressure conditions (e.g., 125/50).

### ✨ Result: The improvement in test coverage
Unit tests for `getBpQuality` are now integrated into the `web-app` test suite, providing confidence in the application's core health metrics logic.

*Note: Tests were manually verified using `node --experimental-strip-types` as `pnpm install` encountered network timeouts in the environment.*

---
*PR created automatically by Jules for task [13317101032536437433](https://jules.google.com/task/13317101032536437433) started by @tcjr*