### PR TITLE
🔒 [security fix] Add input validation for report title

### DIFF
--- a/packages/functions/src/create-report.mts
+++ b/packages/functions/src/create-report.mts
@@ -1,6 +1,14 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import * as logger from 'firebase-functions/logger';
 import setup from './utils/setup.mjs';
+import { z } from 'zod';
+
+const CreateReportSchema = z.object({
+  title: z.string().min(1).max(100),
+  startDate: z.string().datetime(),
+  endDate: z.string().datetime(),
+  measurements: z.array(z.enum(['bps', 'glucoses', 'weights'])),
+});
 
 interface CreateReportData {
   title: string;
@@ -21,7 +29,16 @@ export const createReport = onCall<CreateReportData>(
     }
 
     const { collections } = await setup();
-    const { title, startDate, endDate, measurements } = request.data;
+
+    const validationResult = CreateReportSchema.safeParse(request.data);
+    if (!validationResult.success) {
+      throw new HttpsError(
+        'invalid-argument',
+        `Invalid report data: ${validationResult.error.message}`,
+      );
+    }
+
+    const { title, startDate, endDate, measurements } = validationResult.data;
     const uid = request.auth.uid;
 
     const start = new Date(startDate);

--- a/packages/functions/src/models/report.mts
+++ b/packages/functions/src/models/report.mts
@@ -5,7 +5,7 @@ import { GlucoseSchema } from './glucose.mjs';
 import { WeightSchema } from './weight.mjs';
 
 export const ReportSchema = z.object({
-  title: z.string(),
+  title: z.string().min(1).max(100),
   userId: z.string(),
   startDate: z.date(),
   endDate: z.date(),


### PR DESCRIPTION
🎯 **What:** Missing input validation for the report title in the `createReport` Firebase Function.

⚠️ **Risk:** A malicious user could send an excessively large string, leading to increased database storage costs (DoS), or potentially inject malicious scripts (XSS) if the client application renders this title without escaping it. Arbitrary strings could also cause parsing errors or unexpected behavior in the function's logic.

🛡️ **Solution:** Implemented robust input validation using Zod in both the `ReportSchema` and the `createReport` function. 

Specific changes:
- Updated `packages/functions/src/models/report.mts`: Added `.min(1).max(100)` to the `title` field in `ReportSchema`.
- Updated `packages/functions/src/create-report.mts`:
    - Defined `CreateReportSchema` using Zod to validate the full request payload.
    - Title is constrained to 1-100 characters.
    - `startDate` and `endDate` are validated as ISO 8601 date-time strings.
    - `measurements` is validated as an array containing only permitted enum values ('bps', 'glucoses', 'weights').
    - The function now uses `CreateReportSchema.safeParse(request.data)` and throws a `functions.https.HttpsError` with code `invalid-argument` if validation fails.

These changes ensure that only valid, safe data is stored in the database and processed by the application.

---
*PR created automatically by Jules for task [1245372380965854686](https://jules.google.com/task/1245372380965854686) started by @tcjr*