### PR TITLE
Add test for saving new blood pressure measurement

### DIFF
--- a/packages/web-app/tests/templates/new-bp-test.gts
+++ b/packages/web-app/tests/templates/new-bp-test.gts
@@ -23,7 +23,9 @@ describe('Template | authenticated/new-bp', () => {
 
   renderingTest('it saves new BP measurement', async ({ context }) => {
     const firebaseService = context.owner.lookup('service:firebase');
-    const uidSpy = vi.spyOn(firebaseService, 'uid', 'get').mockReturnValue('test-uid');
+    const uidSpy = vi
+      .spyOn(firebaseService, 'uid', 'get')
+      .mockReturnValue('test-uid');
 
     const flashMessages = context.owner.lookup('service:flash-messages');
     const flashSpy = vi.spyOn(flashMessages, 'success');
@@ -59,7 +61,9 @@ describe('Template | authenticated/new-bp', () => {
         })
       );
       expect(flashSpy).toHaveBeenCalledWith('BP added');
-      expect(transitionToSpy).toHaveBeenCalledWith('authenticated.new-measurement');
+      expect(transitionToSpy).toHaveBeenCalledWith(
+        'authenticated.new-measurement'
+      );
     } finally {
       uidSpy.mockRestore();
       flashSpy.mockRestore();

--- a/packages/web-app/tests/templates/new-bp-test.gts
+++ b/packages/web-app/tests/templates/new-bp-test.gts
@@ -4,6 +4,8 @@ import { click, fillIn, find, render } from '@ember/test-helpers';
 import App from '#app/app.ts';
 import NewBp from '#app/templates/authenticated/new-bp.gts';
 import { collections } from '#app/models/collections.ts';
+import type { FlashMessagesService } from 'ember-cli-flash';
+import type RouterService from '@ember/routing/router-service';
 
 describe('Template | authenticated/new-bp', () => {
   renderingTest.override('app', { scope: 'test' }, () => App);
@@ -27,20 +29,23 @@ describe('Template | authenticated/new-bp', () => {
       .spyOn(firebaseService, 'uid', 'get')
       .mockReturnValue('test-uid');
 
-    const flashMessages = context.owner.lookup('service:flash-messages');
+    const flashMessages = context.owner.lookup(
+      'service:flash-messages'
+    ) as FlashMessagesService;
     const flashSpy = vi.spyOn(flashMessages, 'success');
 
     const router = context.owner.lookup('service:router');
     const transitionToSpy = vi
       .spyOn(router, 'transitionTo')
-      .mockImplementation(() => Promise.resolve() as any);
+      .mockImplementation((() =>
+        Promise.resolve()) as unknown as RouterService['transitionTo']);
 
     const addSpy = vi.fn().mockResolvedValue({});
     const collectionsSpy = vi.spyOn(collections, 'app-users').mockReturnValue({
       bps: {
         add: addSpy,
       },
-    } as any);
+    } as unknown as ReturnType<(typeof collections)['app-users']>);
 
     try {
       await render(<template><NewBp /></template>);
@@ -57,6 +62,7 @@ describe('Template | authenticated/new-bp', () => {
           systolic: 130,
           diastolic: 90,
           heartRate: 85,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           timestamp: expect.any(Date),
         })
       );

--- a/packages/web-app/tests/templates/new-bp-test.gts
+++ b/packages/web-app/tests/templates/new-bp-test.gts
@@ -1,8 +1,9 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 import { renderingTest } from 'ember-vitest';
-import { find, render } from '@ember/test-helpers';
+import { click, fillIn, find, render } from '@ember/test-helpers';
 import App from '#app/app.ts';
 import NewBp from '#app/templates/authenticated/new-bp.gts';
+import { collections } from '#app/models/collections.ts';
 
 describe('Template | authenticated/new-bp', () => {
   renderingTest.override('app', { scope: 'test' }, () => App);
@@ -20,7 +21,50 @@ describe('Template | authenticated/new-bp', () => {
     expect(diaInput.value).toBe('80');
   });
 
-  // TODO: Test to write:
-  // - on "save" click, it calls add() on correct collection with correct data
-  //   and shows "BP added" flash message
+  renderingTest('it saves new BP measurement', async ({ context }) => {
+    const firebaseService = context.owner.lookup('service:firebase');
+    const uidSpy = vi.spyOn(firebaseService, 'uid', 'get').mockReturnValue('test-uid');
+
+    const flashMessages = context.owner.lookup('service:flash-messages');
+    const flashSpy = vi.spyOn(flashMessages, 'success');
+
+    const router = context.owner.lookup('service:router');
+    const transitionToSpy = vi
+      .spyOn(router, 'transitionTo')
+      .mockImplementation(() => Promise.resolve() as any);
+
+    const addSpy = vi.fn().mockResolvedValue({});
+    const collectionsSpy = vi.spyOn(collections, 'app-users').mockReturnValue({
+      bps: {
+        add: addSpy,
+      },
+    } as any);
+
+    try {
+      await render(<template><NewBp /></template>);
+
+      await fillIn('#systolic', '130');
+      await fillIn('#diastolic', '90');
+      await fillIn('#heartRate', '85');
+
+      await click('button[type="submit"]');
+
+      expect(collectionsSpy).toHaveBeenCalledWith('test-uid');
+      expect(addSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systolic: 130,
+          diastolic: 90,
+          heartRate: 85,
+          timestamp: expect.any(Date),
+        })
+      );
+      expect(flashSpy).toHaveBeenCalledWith('BP added');
+      expect(transitionToSpy).toHaveBeenCalledWith('authenticated.new-measurement');
+    } finally {
+      uidSpy.mockRestore();
+      flashSpy.mockRestore();
+      transitionToSpy.mockRestore();
+      collectionsSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
This PR implements the missing test case for saving a new blood pressure measurement in the `NewBp` component.

The test verifies that:
1.  User input for systolic, diastolic, and heart rate is correctly filled.
2.  Clicking the "Save" button triggers the data submission.
3.  The `add()` method of the blood pressure collection is called with the correctly parsed numeric data and a timestamp.
4.  A success flash message "BP added" is displayed upon successful save.
5.  The application transitions back to the "new-measurement" screen.

Note: Due to environment limitations (network timeouts during `pnpm install` preventing the availability of test binaries), local test execution was blocked. However, the implementation follows established patterns in the codebase and has been manually verified for logic correctness during code review.

---
*PR created automatically by Jules for task [6808110974435716734](https://jules.google.com/task/6808110974435716734) started by @tcjr*